### PR TITLE
Add -flto to reduce binary size

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ CFLAGS += -mcpu=cortex-m0 -mthumb
 CFLAGS += -MD -MP -MT $(BUILD)/$(*F).o -MF $(BUILD)/$(@F).d
 CFLAGS += -g3
 CFLAGS += -Wno-unused-parameter -Wno-unused-function -Wno-unused-variable # suppress warnings that happen OFTEN with STM32 library code
+CFLAGS += -flto
 
 LDFLAGS += -mcpu=cortex-m0 -mthumb
 LDFLAGS += -Wl,--gc-sections


### PR DESCRIPTION
When using gcc 11 the build fails because of the .text size:



```
$  make clean && make -j12
clean
CC build/main.o
CC build/stm32f0xx_hal.o
CC build/stm32f0xx_hal_cortex.o
CC build/stm32f0xx_hal_dma.o
CC build/stm32f0xx_hal_gpio.o
CC build/stm32f0xx_hal_msp.o
CC build/stm32f0xx_hal_pcd.o
CC build/stm32f0xx_hal_pcd_ex.o
CC build/stm32f0xx_hal_rcc.o
CC build/stm32f0xx_hal_rcc_ex.o
CC build/stm32f0xx_hal_uart.o
CC build/stm32f0xx_hal_uart_ex.o
CC build/stm32f0xx_it.o
CC build/system_stm32f0xx.o
CC build/usbd_cdc.o
CC build/usbd_composite.o
CC build/usbd_conf.o
CC build/usbd_core.o
CC build/usbd_ctlreq.o
CC build/usbd_desc.o
CC build/usbd_ioreq.o
CC build/startup_stm32f0xx.o
CC build/stm32f0xx_hal_adc.o
CC build/stm32f0xx_hal_adc_ex.o
CC build/stm32f0xx_ll_adc.o
CC build/adc.o
CC build/stm32f0xx_hal_spi_ex.o
CC build/stm32f0xx_hal_spi.o
CC build/stm32f0xx_ll_spi.o
CC build/spi.o
CC build/w25qxx.o
LD build/stm32cdcuart.elf
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld: build/stm32cdcuart.elf section `.text' will not fit in region `flash'
/usr/lib/gcc/arm-none-eabi/11.2.0/../../../../arm-none-eabi/bin/ld: region `flash' overflowed by 48 bytes
collect2: error: ld returned 1 exit status
make: *** [Makefile:75: build/stm32cdcuart.elf] Error 1
$ arm-none-eabi-gcc --version
arm-none-eabi-gcc (Arch Repository) 11.2.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Adding -flto fixes this:

```$ git show
commit 8b12628b44a89398c63ac36897754ca7b89d9e26 (HEAD -> master)
Author: Justin Vreeland <vreeland.justin@gmail.com>
Date:   Sat Dec 11 15:05:38 2021 -0800

    Add -flto to reduce binary size

diff --git a/src/Makefile b/src/Makefile
index a9b1674..6a4af51 100755
--- a/src/Makefile
+++ b/src/Makefile
@@ -18,6 +18,7 @@ CFLAGS += -mcpu=cortex-m0 -mthumb
 CFLAGS += -MD -MP -MT $(BUILD)/$(*F).o -MF $(BUILD)/$(@F).d
 CFLAGS += -g3
 CFLAGS += -Wno-unused-parameter -Wno-unused-function -Wno-unused-variable # suppress warnings that happen OFTEN with STM32 library code
+CFLAGS += -flto
 
 LDFLAGS += -mcpu=cortex-m0 -mthumb
 LDFLAGS += -Wl,--gc-sections

$  make clean && make -j12
clean
CC build/main.o
CC build/stm32f0xx_hal.o
CC build/stm32f0xx_hal_cortex.o
CC build/stm32f0xx_hal_dma.o
CC build/stm32f0xx_hal_gpio.o
CC build/stm32f0xx_hal_msp.o
CC build/stm32f0xx_hal_pcd.o
CC build/stm32f0xx_hal_pcd_ex.o
CC build/stm32f0xx_hal_rcc.o
CC build/stm32f0xx_hal_rcc_ex.o
CC build/stm32f0xx_hal_uart.o
CC build/stm32f0xx_hal_uart_ex.o
CC build/stm32f0xx_it.o
CC build/system_stm32f0xx.o
CC build/usbd_cdc.o
CC build/usbd_composite.o
CC build/usbd_conf.o
CC build/usbd_core.o
CC build/usbd_ctlreq.o
CC build/usbd_desc.o
CC build/usbd_ioreq.o
CC build/startup_stm32f0xx.o
CC build/stm32f0xx_hal_adc.o
CC build/stm32f0xx_hal_adc_ex.o
CC build/stm32f0xx_ll_adc.o
CC build/adc.o
CC build/stm32f0xx_hal_spi_ex.o
CC build/stm32f0xx_hal_spi.o
CC build/stm32f0xx_ll_spi.o
CC build/spi.o
CC build/w25qxx.o
LD build/stm32cdcuart.elf
OBJCOPY build/stm32cdcuart.hex
OBJCOPY build/stm32cdcuart.bin
elf2dfuse build/stm32cdcuart.dfu
./elf2dfuse build/stm32cdcuart.elf build/stm32cdcuart.dfu
size:
   text	  data	   bss	   dec	   hex	filename
  14328	     0	  4756	 19084	  4a8c	build/stm32cdcuart.elf
  14328	     0	  4756	 19084	  4a8c	(TOTALS)
  ```
  
  I flashed this image to my Honeycomb and it seems to be working.